### PR TITLE
Proof of concept merge TCP connection capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Integrate the [Rainforest EMU-2](https://www.rainforestautomation.com/rfa-z105-2
 
 1. Install [HACS](https://hacs.xyz)
 1. Through the HACS integration, search for and install "Rainforest EMU-2"
-1. Choose from one of the detected serial ports
+1. Choose from one of the detected serial ports, or enter a host name and TCP port number when using a USB>TCP adapter to remotely locate your EMU-2 device
 
 # Configuration
 

--- a/custom_components/rainforest_emu_2/__init__.py
+++ b/custom_components/rainforest_emu_2/__init__.py
@@ -15,7 +15,9 @@ from homeassistant.const import (
     ATTR_MANUFACTURER,
     ATTR_MODEL,
     ATTR_HW_VERSION,
-    ATTR_SW_VERSION
+    ATTR_SW_VERSION,
+    CONF_HOST,
+    CONF_PORT
 )
 
 from .emu2 import Emu2
@@ -74,8 +76,8 @@ class RainforestEmu2Device:
         self._current_price = None
         self._current_usage = None
         self._current_usage_start_date = dt.utc_from_timestamp(0)
-
-        self._emu2 = Emu2(properties[ATTR_DEVICE_PATH])
+  
+        self._emu2 = Emu2(properties[ATTR_DEVICE_PATH], properties[CONF_HOST], properties[CONF_PORT])
         self._emu2.register_process_callback(self._process_update)
 
         self._serial_loop_task = self._hass.loop.create_task(self._emu2.serial_read())

--- a/custom_components/rainforest_emu_2/translations/en.json
+++ b/custom_components/rainforest_emu_2/translations/en.json
@@ -12,7 +12,9 @@
             },
             "manual": {
                 "data": {
-                    "device_path": "Device path"
+                    "device_path": "Device path, or leave blank for TCP connection",
+					"host": "IP Address or Domain name of the USB>TCP converter",
+					"port": "TCP port on the USB>TCP converter"
                 },
                 "description": "Set up the Rainforest EMU-2 device integration"
             }


### PR DESCRIPTION
I have been maintaining a parallel development to your component for about a year. 

See: https://github.com/HyperActiveJ/home-assistant-rainforest-emu2-tcp

Basically I found my HA server is too far from my meter for the EMU-2 to keep a reliable connection, so I use a RPI Zero W to forward the serial data over TCP to my docker instance of HA.

I discovered your integration about an hour ago and realized that I would be better off by adding my remote connection requirement to your component, rather then continuing to maintain a completely separate repo.  Fortunately it appears to have worked with while only adding a few lines to your code base.

If you don't want this feature then that's fine. I'm happy to keep my fork up to date and contribute in other was back when I can.
If your interested, then consider this pull request as a quick proof of concept. I'm open to feedback on what you would want to see before merging it
