### PR TITLE
Properly setup with auto discovery, save host and port

### DIFF
--- a/custom_components/rainforest_emu_2/config_flow.py
+++ b/custom_components/rainforest_emu_2/config_flow.py
@@ -66,7 +66,7 @@ class RainforestConfigFlow(config_entries.ConfigFlow, domain = DOMAIN):
                 usb.get_serial_by_id, port.device
             )
 
-            device_properties = await self.async_get_device_properties(device_path)
+            device_properties = await self.async_get_device_properties(device_path, None, None)
             if device_properties is not None:
                 return await self.async_setup_device(device_path, device_properties)
 
@@ -161,6 +161,8 @@ class RainforestConfigFlow(config_entries.ConfigFlow, domain = DOMAIN):
             return {
                 ATTR_DEVICE_PATH: device_path,
                 ATTR_DEVICE_MAC_ID: response.device_mac,
+                CONF_HOST: host,
+                CONF_PORT: port
             }
 
         _LOGGER.debug("get_devices_properties InstantaneousDemand response is None")


### PR DESCRIPTION
* In the auto-discovery code path, `async_get_device_properties()` requires the host and port, which aren't applicable for USB `device_path`. To fix, pass in `None` for those parameters
* When reading the data in the cache to create the `Emu2` object, the dictionary didn't contain the null Port and Host, so it threw the exception. To fix, ensure that when cache is saved, the Host and Port are saved in the config.