### PR TITLE
Fix for TCP connection Hang and Add Connection Sensors

### DIFF
--- a/custom_components/rainforest_emu_2/__init__.py
+++ b/custom_components/rainforest_emu_2/__init__.py
@@ -76,7 +76,7 @@ class RainforestEmu2Device:
         self._current_price = None
         self._current_usage = None
         self._current_usage_start_date = dt.utc_from_timestamp(0)
-  
+
         self._emu2 = Emu2(properties[ATTR_DEVICE_PATH], properties[CONF_HOST], properties[CONF_PORT])
         self._emu2.register_process_callback(self._process_update)
 
@@ -101,6 +101,7 @@ class RainforestEmu2Device:
         self._callbacks.discard((type, callback))
 
     def _process_update(self, type, response) -> None:
+    
         if type == 'InstantaneousDemand':
             self._power = response.reading
 
@@ -114,7 +115,7 @@ class RainforestEmu2Device:
         elif type == 'CurrentSummationDelivered':
             self._summation_delivered = response.delivered
             self._summation_received = response.received
-
+        
         for callback in self._callbacks:
             if (callback[0] == type):
                 callback[1]()
@@ -133,19 +134,19 @@ class RainforestEmu2Device:
 
     @property
     def device_manufacturer(self) -> str:
-        self._properties.get(ATTR_MANUFACTURER)
+        return self._properties.get(ATTR_MANUFACTURER)
 
     @property
     def device_model(self) -> str:
-        self._properties.get(ATTR_MODEL)
+        return self._properties.get(ATTR_MODEL)
 
     @property
     def device_sw_version(self) -> str:
-        self._properties.get(ATTR_SW_VERSION)
+        return self._properties.get(ATTR_SW_VERSION)
 
     @property
     def device_hw_version(self) -> str:
-        self._properties.get(ATTR_HW_VERSION)
+        return self._properties.get(ATTR_HW_VERSION)
 
     @property
     def power(self) -> float:

--- a/custom_components/rainforest_emu_2/config_flow.py
+++ b/custom_components/rainforest_emu_2/config_flow.py
@@ -133,7 +133,7 @@ class RainforestConfigFlow(config_entries.ConfigFlow, domain = DOMAIN):
 
         await emu2.get_device_info()
 
-        await asyncio.sleep(2)
+        await asyncio.sleep(15)
         serial_loop_task.cancel()
 
         try:
@@ -144,6 +144,7 @@ class RainforestConfigFlow(config_entries.ConfigFlow, domain = DOMAIN):
         await emu2.close()
 
         response = emu2.get_data(DeviceInfo)
+        
         if response is not None:
             return {
                 ATTR_DEVICE_PATH: device_path,
@@ -156,16 +157,5 @@ class RainforestConfigFlow(config_entries.ConfigFlow, domain = DOMAIN):
                 CONF_PORT: port
             }
         _LOGGER.debug("get_devices_properties DeviceInfo response is None")
-
-        # For some reason we didnt get a DeviceInfo response, failback to an InstananeousDemand response
-        response = emu2.get_data(InstantaneousDemand)
-        if response is not None:
-            return {
-                ATTR_DEVICE_PATH: device_path,
-                ATTR_DEVICE_MAC_ID: response.device_mac,
-                CONF_HOST: host,
-                CONF_PORT: port
-            }
-
-        _LOGGER.debug("get_devices_properties InstantaneousDemand response is None")
+      
         return None

--- a/custom_components/rainforest_emu_2/emu2.py
+++ b/custom_components/rainforest_emu_2/emu2.py
@@ -101,6 +101,17 @@ class Emu2:
                 break
             
             line = line.decode("utf-8").strip()
+             
+            if "Port already in use" in line:
+                _LOGGER.error("Another client is already connected to the TCP server, disconnect that client and try again.")
+            if len(line) == 0:
+                self._connected = False
+                _LOGGER.error("No Data Received, Disconnecting")
+                await asyncio.sleep(10)
+                await self.open()
+                response = ""
+                               
+            
             _LOGGER.debug("received %d: %s", len(line), line)
 
             response += line

--- a/custom_components/rainforest_emu_2/emu2.py
+++ b/custom_components/rainforest_emu_2/emu2.py
@@ -4,6 +4,7 @@ import itertools
 import logging
 from xml.etree import ElementTree
 from serial import SerialException
+from collections import defaultdict
 
 from . import emu2_entities
 
@@ -26,6 +27,7 @@ class Emu2:
         self._host = host
         self._port = port
         self._data = {}
+        self._initialized = False
 
     def get_data(self, klass):
         _LOGGER.debug("Requesting data %s", klass)
@@ -101,7 +103,7 @@ class Emu2:
                 break
             
             line = line.decode("utf-8").strip()
-             
+            
             if "Port already in use" in line:
                 _LOGGER.error("Another client is already connected to the TCP server, disconnect that client and try again.")
             if len(line) == 0:
@@ -111,14 +113,25 @@ class Emu2:
                 await self.open()
                 response = ""
                                
-            
             _LOGGER.debug("received %d: %s", len(line), line)
-
+              
             response += line
             if line.startswith('</'):
                 try:
-                    self._connected = True
                     self._process_reply(response)
+                    #Upon first recieved message, get the basic data
+                    if not self._connected:
+                        self._connected = True
+                        self._initialized = False
+                        await self.get_device_info()  
+                        await self.get_connection_status()
+                        #await self.get_network_info()
+                        #await self.get_meter_list()
+                    elif not self._initialized:
+                        self._initialized = True
+                        #await self.get_schedule()
+                        #await self.get_meter_info()
+                        await self.set_schedule(None, "demand",  9, True)
                     response = ''
                 except Exception as ex:
                     _LOGGER.error("something went wrong: %s", ex)
@@ -126,7 +139,7 @@ class Emu2:
 
     async def issue_command(self, command, params = None) -> bool:
         if self._connected == False:
-            _LOGGER.error("issued command while not connected")
+            _LOGGER.error("issued command while not connected: " + command)
             return False
 
         root = ElementTree.Element('Command')
@@ -200,6 +213,7 @@ class Emu2:
         if event not in enum:
             raise ValueError('Invalid event specified')
 
+        
     # The following are convenience methods for sending commands. Commands
     # can also be sent manually using the generic issue_command method.
 

--- a/custom_components/rainforest_emu_2/sensor.py
+++ b/custom_components/rainforest_emu_2/sensor.py
@@ -14,9 +14,9 @@ from homeassistant.const import (
     ATTR_MODEL,
     ATTR_HW_VERSION,
     ATTR_SW_VERSION,
-    ENERGY_KILO_WATT_HOUR,
-    POWER_KILO_WATT,
-    CURRENCY_DOLLAR,
+    EntityCategory,
+    UnitOfEnergy,
+    UnitOfPower,
 )
 
 from .const import DOMAIN, DEVICE_NAME
@@ -86,10 +86,6 @@ class Emu2GenericSensor(SensorEntityBase):
         self._command = command
         if command is not None:
             self.should_poll = True
-        
-        #self._attr_device_class = SensorDeviceClass.POWER
-        #self._attr_state_class = SensorStateClass.MEASUREMENT
-        #self._attr_native_unit_of_measurement = POWER_KILO_WATT
 
     async def async_update(self):
         await self._device._emu2.issue_command(self._command)
@@ -113,9 +109,9 @@ class Emu2ActivePowerSensor(SensorEntityBase):
         self._attr_unique_id = f"{self._device.device_id}_power"
         self._attr_name = f"{self._device.device_name} Power"
 
-        self._attr_device_class = SensorDeviceClass.POWER
-        self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_native_unit_of_measurement = POWER_KILO_WATT
+        native_unit_of_measurement=UnitOfPower.KILO_WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
 
     @property
     def state(self):
@@ -131,9 +127,9 @@ class Emu2CurrentPriceSensor(SensorEntityBase):
 
         self._attr_device_class = SensorDeviceClass.MONETARY
         self._attr_state_class = SensorStateClass.MEASUREMENT
-        self._attr_native_unit_of_measurement = (
-            f"{CURRENCY_DOLLAR}/{ENERGY_KILO_WATT_HOUR}"
-        )
+        #self._attr_native_unit_of_measurement = (
+        #   f"{CURRENCY_DOLLAR}/{UnitOfEnergy.KILO_WATT_HOUR}"
+        #)
 
     async def async_update(self):
         await self._device._emu2.get_current_price()
@@ -150,9 +146,9 @@ class Emu2CurrentPeriodUsageSensor(SensorEntityBase):
         self._attr_unique_id = f"{self._device.device_id}_current_period_usage"
         self._attr_name = f"{self._device.device_name} Current Period Usage"
 
-        self._attr_device_class = SensorDeviceClass.ENERGY
-        self._attr_state_class = SensorStateClass.TOTAL
-        self._attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
 
     async def async_update(self):
         await self._device._emu2.get_current_period_usage()
@@ -175,9 +171,9 @@ class Emu2SummationDeliveredSensor(SensorEntityBase):
         self._attr_unique_id = f"{self._device.device_id}_summation_delivered"
         self._attr_name = f"{self._device.device_name} Summation Delivered"
 
-        self._attr_device_class = SensorDeviceClass.ENERGY
-        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-        self._attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
 
     @property
     def state(self):
@@ -194,9 +190,9 @@ class Emu2SummationReceivedSensor(SensorEntityBase):
         self._attr_unique_id = f"{self._device.device_id}_summation_received"
         self._attr_name = f"{self._device.device_name} Summation Received"
 
-        self._attr_device_class = SensorDeviceClass.ENERGY
-        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
-        self._attr_native_unit_of_measurement = ENERGY_KILO_WATT_HOUR
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        device_class=SensorDeviceClass.ENERGY,
+        state_class=SensorStateClass.TOTAL_INCREASING,
 
     @property
     def state(self):


### PR DESCRIPTION
Fixes HA crash when the remote TCP server is not allowing connections. - Issue #23 
Retries TCP connection automatically and regathers some meter each time.
Fixes missing device info data when TCP connection is slow.
Adds connection status sensors to make it easy to see if its a problem with the integration, or if the device is having a hard time connecting to the meter.

Feel free to edit to your liking.
